### PR TITLE
adding bower.json so this library could be registered as a bower package

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,18 @@
+{
+  "name": "Leaflet.MovingMarker",
+  "version": "0.5.0",
+  "main": "MovingMarker.js",
+  "ignore": [
+    ".jshintrc",
+    "**/*.txt",
+    ".gitignore",
+    ".jshintignore",
+    ".jshintrc",
+    "bower.json"
+  ],
+  "dependencies": {
+      "leaflet": "~0.7.2"
+  },
+  "devDependencies": {
+  }
+}


### PR DESCRIPTION
I've added a bower.json file that will allow this package to be registered and uploaded to the bower registry. I have not registered it, since it's your code and I wanted to give you first shot. Here's the command to do it:

    bower register Leaflet.MovingMarker git@github.com:ewoken/Leaflet.MovingMarker.git

Let me know if you have any questions.