### PR TITLE
Adjust animation speed

### DIFF
--- a/MovingMarker.js
+++ b/MovingMarker.js
@@ -28,6 +28,15 @@ L.Marker.MovingMarker = L.Marker.extend({
         });
 
         this._durations = durations;
+        this._speed = 1;
+        Object.defineProperty(this, '_currentDuration', {
+            set: function(duration) {
+                this.__currentDuration = duration;
+            },
+            get: function() {
+                return this.__currentDuration / this._speed;
+            }
+        });
         this._currentDuration = 0;
         this._currentIndex = 0;
 
@@ -75,9 +84,23 @@ L.Marker.MovingMarker = L.Marker.extend({
             return;
         }
         // update the current line
-        this._currentLine[0] = this.getLatLng(); 
-        this._currentDuration -= (this._pauseStartTime - this._startTime);
         this._startAnimation();
+    },
+
+    setSpeed: function(speed) {
+        if (! this.isPaused()) {
+            this._stopAnimation();
+            var speedChangeTime = Date.now();
+
+            this._currentLine[0] = this.getLatLng();
+            this._currentDuration = (this._currentDuration - (speedChangeTime - this._startTime))*this._speed;
+
+            this._speed = speed;
+
+            this._startAnimation();
+        } else {
+            this._speed = speed;
+        }
     },
 
     addLatLng: function(latlng, duration) {
@@ -235,6 +258,9 @@ L.Marker.MovingMarker = L.Marker.extend({
         //force animation to place the marker at the right place
         this._animate(this._startTimeStamp
             + (this._pauseStartTime - this._startTime), true);
+
+        this._currentLine[0] = this.getLatLng();        
+        this._currentDuration = (this._currentDuration - (this._pauseStartTime - this._startTime))*this._speed;
     },
 
     stop: function(elapsedTime) {

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ All the marker's options are available.
  - ```start()```:  the marker begins its path or resumes if it is paused.
  - ``` stop()```: manually stops the marker, if you call ```start`` after, the marker starts again the polyline at the beginning.
  - ```pause()```: just pauses the marker
+ - ```setSpeed(number)```: the marker will move the multiple fast, i.e. `setSpeed(2)` is the double speed
  - ``` resume()```: the marker resumes its animation
  - ```addLatLng(latlng, duration)```: adds a point to the polyline. Useful, if we have to set the path one by one.
  - ``` moveTo(latlng, duration)```: stops current animation and make the marker move to ```latlng``` in ```duration``` ms. 

--- a/examples/script.js
+++ b/examples/script.js
@@ -48,8 +48,11 @@ marker1.openPopup();
 //========================================================================
 
 var marker2 = L.Marker.movingMarker(londonParisRomeBerlinBucarest,
-    [3000, 9000, 9000, 4000], {autostart: true}).addTo(map);
+    [3000, 9000, 9000, 8000], {autostart: true}).addTo(map);
 L.polyline(londonParisRomeBerlinBucarest, {color: 'red'}).addTo(map);
+setTimeout(function() {
+    marker2.setSpeed(2);
+},23000)
 
 
 marker2.on('end', function() {
@@ -94,5 +97,26 @@ marker3.on('loop', function(e) {
 map.on("click", function(e) {
     marker4.moveTo(e.latlng, 2000);
 });
+
+
+var marker5 = L.Marker.movingMarker([[50.85, 4.35], [50.45, 30.523333], [50.85, 4.35]], [12000, 12000]).addTo(map);
+
+var start = Date.now();
+marker5.start();
+setTimeout(function() {
+    marker5.pause();
+}, 6000)
+setTimeout(function() {
+    marker5.setSpeed(2);
+}, 9000)
+setTimeout(function() {
+    marker5.resume();
+}, 12000)
+setTimeout(function() {
+    marker5.setSpeed(1);
+}, 18000)
+marker5.on('end', function() {
+    console.log('Approx 24s: ', Date.now() - start); // approx 24000
+})
 
 //=========================================================================


### PR DESCRIPTION
I've added a `marker.setSpeed(number)` option to adjust the speed of the animation. `setSpeed(2)` is double speed, `setSpeed(1)` is normal.
This method works both on running markers and paused ones. Examples were added.