### PR TITLE
README corrected factory code + moved note

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,15 +50,13 @@ API
 
 **Factory**
 ```
-L.movingMarker(<LatLng[]> latlngs, <Number[]> durations [,<Object> options]);
+L.Marker.movingMarker(<LatLng[]> latlngs, <Number[]> durations [,<Object> options]);
 ```
+Note: As Leaftlet's other functions, it also accepts `latlngs` in a simple Array form and simple object form ([see Leaflet docs](http://leafletjs.com/reference.html#latlng)).
 
 **durations**:
 *   if array of number : duration in ms per line segment.
 *   if number : total duration (autocalculate duration in ms per line segment proportionnaly to distance between points).
-
-
-Note: As Leaftlet's other functions, it also accept them in a simple Array form and simple object form ([see Leaflet docs](http://leafletjs.com/reference.html#latlng)).
 
 **Options**
 All the marker's options are available.


### PR DESCRIPTION
to match source in [MovingMarker.js line 302](https://github.com/ewoken/Leaflet.MovingMarker/blob/master/MovingMarker.js#L302).
Moved note about simple `latlngs` form just below the factory code, instead of after durations.

Note: about factory, please note that Leaflet convention is to use camelCase for factory, including for parent properties, except `L`. See for example [`L.control.layers`](http://leafletjs.com/reference.html#control-layers-l.control.layers).

So `L.Marker.movingMarker` could be converted to `L.marker.movingMarker` for consistency.
