### PR TITLE
Add lineIndexChanged Event

### DIFF
--- a/MovingMarker.js
+++ b/MovingMarker.js
@@ -210,7 +210,7 @@ L.Marker.MovingMarker = L.Marker.extend({
 
     _loadLine: function(index) {
         if (this._currentIndex !== index) {
-            this.fire('segmentChanged', { segmentIndex: index });
+            this.fire('lineIndexChanged', { lineIndex: index });
         }
 
         this._currentIndex = index;

--- a/MovingMarker.js
+++ b/MovingMarker.js
@@ -209,6 +209,10 @@ L.Marker.MovingMarker = L.Marker.extend({
     },
 
     _loadLine: function(index) {
+        if (this._currentIndex !== index) {
+            this.fire('segmentChanged', { segmentIndex: index });
+        }
+
         this._currentIndex = index;
         this._currentDuration = this._durations[index];
         this._currentLine = this._latlngs.slice(index, index + 2);

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ All the marker's options are available.
  - ```start```: fired when the marker starts
  - ``` end```: fired when the marker stops 
  - ```loop```: fired when the marker begin a new loop
+ - ```lineIndexChanged```: fired when the marker moves to a new line
 
 **Note**: Event are not synchrone because of the use of ```requestAnimationFrame```.  If you quit the tab where the animation is working, events will be fired when the tab will get back the focus. Events ```end``` and ```loop``` have the attribute ```elapsedTime``` to get the time elapsed since the real end/loop.
 


### PR DESCRIPTION
I've added a new event for when the lineIndex is changed. I needed this for a project I was working on so that I could update a separate view based on what part of the polyLine the marker was on.

The naming could be changed, I just used lineIndex
